### PR TITLE
Implemented P08 from `Ninety-Nine Scala Problems`

### DIFF
--- a/src/main/scala/P08.scala
+++ b/src/main/scala/P08.scala
@@ -1,0 +1,16 @@
+/*
+If a list contains repeated elements they should be replaced with a single copy of the element.
+The order of the elements should not be changed.
+Example:
+
+scala> compress(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
+res0: List[Symbol] = List('a, 'b, 'c, 'a, 'd, 'e)
+ */
+
+object P08 {
+  def compress[T](symbols: List[T]): List[T] = symbols match {
+    case a :: b :: rest if (a == b) ⇒ compress(a :: rest)
+    case a :: rest                  ⇒ a :: compress(rest)
+    case Nil                        ⇒ Nil
+  }
+}

--- a/src/test/scala/P08Spec.scala
+++ b/src/test/scala/P08Spec.scala
@@ -1,0 +1,7 @@
+import org.scalatest._
+
+class P08Spec extends FlatSpec with Matchers {
+  "compress" should "eliminate consecutive duplicate values" in {
+    P08.compress(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) should be(List('a, 'b, 'c, 'a, 'd, 'e))
+  }
+}


### PR DESCRIPTION
If a list contains repeated elements they should be replaced with a single copy of the element.
The order of the elements should not be changed.
