### PR TITLE
Implemented P10

### DIFF
--- a/src/main/scala/P10.scala
+++ b/src/main/scala/P10.scala
@@ -1,0 +1,37 @@
+
+/*
+Run-length encoding of a list.
+Use the result of problem P09 to implement the so-called run-length encoding data compression method.
+Consecutive duplicates of elements are encoded as tuples (N, E) where N is the number of duplicates of the element E.
+Example:
+
+scala> encode(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e))
+res0: List[(Int, Symbol)] = List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e))
+*/
+object P10 {
+  def encode1[T](symbols: List[T]): List[(Int, T)] = symbols match {
+    case s1 :: rest1 ⇒ encode1(rest1) match {
+      case (c, s2) :: rest2 if (s1 == s2) ⇒ (c + 1, s2) :: rest2
+      case s                              ⇒ (1, s1) :: s
+    }
+    case _           ⇒ Nil
+  }
+
+  def encode2[T](symbols: List[T]) = {
+    def encode(symbols: List[(Int, T)]): List[(Int, T)] = symbols match {
+      case (c, s1) :: (1, s2) :: rest if (s1 == s2) ⇒ encode((c + 1, s1) :: rest)
+      case (c, s) :: rest                           ⇒ (c, s) :: encode(rest)
+      case _                                        ⇒ Nil
+    }
+    encode(Stream.continually(1) zip symbols toList)
+  }
+
+  def encode3[T](symbols: List[T]) = {
+    def aggregate(state: List[(Int, T)], event: T) = state match {
+      case (c, s) :: rest if (s == event) ⇒ (c + 1, event) :: rest
+      case (c, s) :: rest                 ⇒ (1, event) :: state
+      case _                              ⇒ List((1, event))
+    }
+    symbols.foldLeft(List(): List[(Int, T)])(aggregate).reverse
+  }
+}

--- a/src/test/scala/P10Spec.scala
+++ b/src/test/scala/P10Spec.scala
@@ -1,0 +1,16 @@
+import org.scalatest._
+
+class P10Spec extends FlatSpec with Matchers {
+  "encode1" should "the run-length encoding of the list" in {
+    P10.encode1(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) should be(List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e)))
+  }
+  
+  "encode2" should "the run-length encoding of the list" in {
+    P10.encode2(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) should be(List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e)))
+  }
+  
+  "encode3" should "the run-length encoding of the list" in {
+    P10.encode3(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) should be(List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e)))
+  }
+}
+


### PR DESCRIPTION
Run-length encoding of a list.
Use the result of problem P09 to implement the so-called run-length encoding data compression method.
Consecutive duplicates of elements are encoded as tuples (N, E) where N is the number of duplicates of the element E.

We implemented it in 3 different methods
